### PR TITLE
Get CI off of about-to-be-removed Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build_and_test:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 

--- a/.github/workflows/debian_package.yml
+++ b/.github/workflows/debian_package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   debian_package:
     name: Build Debian package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/11101